### PR TITLE
More consistent use of JetSpace

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "TaylorModels"
 uuid = "314ce334-5f6e-57ae-acf6-00b6e903104a"
-version = "0.11.0"
+version = "0.11.1"
 repo = "https://github.com/JuliaIntervals/TaylorModels.jl.git"
 
 [deps]

--- a/src/TaylorModels.jl
+++ b/src/TaylorModels.jl
@@ -23,7 +23,7 @@ using TaylorSeries: derivative, ∇
 
 import TaylorSeries: integrate, order, evaluate, pretty_print,
     constant_term, linear_polynomial, nonlinear_polynomial,
-    fixorder, get_numvars
+    fixorder, get_numvars, space
 
 import LinearAlgebra: norm
 

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -526,7 +526,7 @@ end
 # Multiplication
 function *(a::TaylorModelN, b::TaylorModelN)
     @assert all(isequal_interval.(tmdata(a), tmdata(b)))
-    @assert TS.order(a)+TS.order(b) ≤ TS.order()
+    @assert TS.order(a)+TS.order(b) ≤ TS.order(TS.space(polynomial(a)))
     # Returned polynomial
     res = a.pol * b.pol
     # Remainder
@@ -599,7 +599,7 @@ end
 # Power
 # Square
 function TS.square(a::TaylorModelN)
-    @assert 2*TS.order(a) ≤ TS.order()
+    @assert 2*TS.order(a) ≤ TS.order(TS.space(polynomial(a)))
     res = TS.square(a.pol)
     Δ = remainder_square(a, TS.order(res))
     return TaylorModelN(res, Δ, expansion_point(a), domain(a))

--- a/src/arithmetic.jl
+++ b/src/arithmetic.jl
@@ -486,9 +486,11 @@ end
 
 
 # Same as above, for TaylorModelN
-zero(a::TaylorModelN) = TaylorModelN(TaylorN(zero(a.pol[0]), TS.order(a.pol)),
+zero(a::TaylorModelN) = TaylorModelN(
+    TaylorN(space(a), zero(a.pol.coeffs[1].coeffs[1]), TS.order(a.pol)),
     zero(remainder(a)), expansion_point(a), domain(a))
-one(a::TaylorModelN) = TaylorModelN(TaylorN(one(a.pol[0]), TS.order(a.pol)),
+one(a::TaylorModelN) = TaylorModelN(
+    TaylorN(space(a), one(a.pol.coeffs[1].coeffs[1]), TS.order(a.pol)),
     zero(remainder(a)), expansion_point(a), domain(a))
 zero(a::Taylor1{TaylorModelN{N,T,S}}) where {N,T,S} = Taylor1(zero(a[0]), TS.order(a))
 
@@ -526,7 +528,7 @@ end
 # Multiplication
 function *(a::TaylorModelN, b::TaylorModelN)
     @assert all(isequal_interval.(tmdata(a), tmdata(b)))
-    @assert TS.order(a)+TS.order(b) ≤ TS.order(TS.space(polynomial(a)))
+    @assert TS.order(a)+TS.order(b) ≤ TS.order(space(a))
     # Returned polynomial
     res = a.pol * b.pol
     # Remainder
@@ -563,7 +565,7 @@ function _neglected_polynomial(a::TaylorModelN{N,T,S}, b::TaylorModelN{N,T,S},
     z = zero(R)
     suma = Vector{promote_type(R,D)}(undef, rnegl_order-_order)
     for k in _order+1:rnegl_order
-        tmp = HomogeneousPolynomial(z, k)
+        tmp = HomogeneousPolynomial(space(a), z, k)
         @inbounds for i = 0:k
             (i > a_order || k-i > b_order) && continue
             TS.mul!(tmp, a.pol[i], b.pol[k-i])
@@ -599,7 +601,7 @@ end
 # Power
 # Square
 function TS.square(a::TaylorModelN)
-    @assert 2*TS.order(a) ≤ TS.order(TS.space(polynomial(a)))
+    @assert 2*TS.order(a) ≤ TS.order(space(a))
     res = TS.square(a.pol)
     Δ = remainder_square(a, TS.order(res))
     return TaylorModelN(res, Δ, expansion_point(a), domain(a))
@@ -615,7 +617,7 @@ function remainder_square(a::TaylorModelN{N,T,S},
     suma = Array{promote_type(TS.numtype(a.pol),
                     TS.numtype(domain(a)))}(undef, rnegl_order-_order)
     for k in _order+1:rnegl_order
-        vv[k-_order] = HomogeneousPolynomial(zero(TS.numtype(a.pol)), k)
+        vv[k-_order] = HomogeneousPolynomial(space(a), zero(TS.numtype(a.pol)), k)
         @inbounds for i = 0:k
             (i > a_order || k-i > a_order) && continue
             TS.mul!(vv[k-_order], a.pol[i], a.pol[k-i])

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -52,7 +52,8 @@ setindex!(a::TaylorModel1{TaylorModelN{N,T,S},S}, x::TaylorModelN{N,T,S},
 setindex!(a::Taylor1{TaylorModelN{N,T,S}}, x::TaylorModelN{N,T,S},
         n::Int) where {N,T,S} =
     setindex!(a.coeffs,
-        TaylorModelN(TaylorN(x.pol.coeffs[:], TS.order(x.pol)), x.rem, x.x0[:], x.dom[:]), n+1)
+        TaylorModelN(TaylorN(space(x), x.pol.coeffs[:], TS.order(x.pol)),
+            x.rem, x.x0[:], x.dom[:]), n+1)
 
 
 """
@@ -135,7 +136,7 @@ end
 function bound_truncation(::Type{TaylorModelN}, a::TaylorN, aux::AbstractVector{<:Interval},
         order::Int)
     order ≥ TS.order(a) && return zero(aux[1])
-    res = TaylorN(a.coeffs[:], TS.order(a))
+    res = TaylorN(space(a), a.coeffs[:], TS.order(a))
     res[0:order] .= zero(res[0])
     return res(aux)
 end

--- a/src/auxiliary.jl
+++ b/src/auxiliary.jl
@@ -12,10 +12,10 @@ for TM in (:TaylorModel1, :RTaylorModel1, :TaylorModelN)
         @inline Base.iterate(a::$TM, state=0) = state ≥ lastindex(a) ? nothing : (a[state+1], state+1)
         @inline Base.eachindex(a::$TM) = firstindex(a):lastindex(a)
 
-        getindex(a::$TM, n::Integer) = getindex(polynomial(a), n)
-        getindex(a::$TM, u::UnitRange) = getindex(polynomial(a), u)
-        getindex(a::$TM, c::Colon) = getindex(polynomial(a), c)
-        # getindex(a::$TM, u::StepRange{Int,Int}) = getindex(polynomial(a), u)
+        getindex(a::$TM, n::Integer) = a.pol.coeffs[n+1]
+        getindex(a::$TM, u::UnitRange) = a.pol.coeffs[u .+ 1]
+        getindex(a::$TM, c::Colon) = a.pol.coeffs[c]
+        # getindex(a::$TM, u::StepRange{Int,Int}) = a.pol.coeffs[u .+ 1]
 
         constant_term(a::$TM) = constant_term(polynomial(a))
         linear_polynomial(a::$TM) = linear_polynomial(polynomial(a))
@@ -29,12 +29,12 @@ end
 # setindex, iscontained
 for TM in tupleTMs
     @eval begin
-        setindex!(a::$TM{T,S}, x::T, n::Integer) where {T<:Number, S} = a.pol[n] = x
-        setindex!(a::$TM{T,S}, x::T, u::UnitRange) where {T<:Number, S} = a.pol[u] .= x
+        setindex!(a::$TM{T,S}, x::T, n::Integer) where {T<:Number, S} = a.pol.coeffs[n+1] = x
+        setindex!(a::$TM{T,S}, x::T, u::UnitRange) where {T<:Number, S} = a.pol.coeffs[u .+ 1] .= x
         function setindex!(a::$TM{T,S}, x::Array{T,1}, u::UnitRange) where {T<:Number, S}
             @assert length(u) == length(x)
             for ind in eachindex(x)
-                a.pol[u[ind]] = x[ind]
+                a.pol.coeffs[u[ind]+1] = x[ind]
             end
         end
         setindex!(a::$TM{T,S}, x::T, c::Colon) where {T<:Number, S} = a[c] .= x
@@ -48,11 +48,11 @@ iscontained(a, tm::TaylorModelN) = all(in_interval.(a, centered_dom(tm)))
 iscontained(a::AbstractVector{<:Interval}, tm::TaylorModelN) =
     all(issubset_interval.(a, centered_dom(tm)))
 setindex!(a::TaylorModel1{TaylorModelN{N,T,S},S}, x::TaylorModelN{N,T,S},
-    n::Int) where {N,T,S} = a.pol[n] = x
+    n::Int) where {N,T,S} = a.pol.coeffs[n+1] = x
 setindex!(a::Taylor1{TaylorModelN{N,T,S}}, x::TaylorModelN{N,T,S},
-        n::Int) where {N,T,S} = setindex!(a.coeffs,
-    TaylorModelN(TaylorN(x.pol.coeffs[:], TS.order(x.pol)), x.rem, x.x0[:], x.dom[:]),
-    n+1)
+        n::Int) where {N,T,S} =
+    setindex!(a.coeffs,
+        TaylorModelN(TaylorN(x.pol.coeffs[:], TS.order(x.pol)), x.rem, x.x0[:], x.dom[:]), n+1)
 
 
 """
@@ -93,7 +93,7 @@ for TM in tupleTMs
             order_a = TS.order(a)
             order ≥ order_a && return zero(aux)
             if $TM == TaylorModel1
-                res = Taylor1(copy(a.coeffs))
+                res = Taylor1(a.coeffs, order_a)
                 res[0:order] .= zero(res[0])
             else
                 res = Taylor1(a.coeffs[order+2:end], order_a-order )

--- a/src/bounds.jl
+++ b/src/bounds.jl
@@ -256,8 +256,8 @@ of the `TaylorModelN` included.
 """ linear_dominated_bounder
 
 for TT = (:T, :(Interval{T}))
-    @eval function linear_dominated_bounder(fT::TaylorModelN{N,$TT,S}; ϵ=1e-5, max_iter=5) where
-            {N,T<:IANumTypes, S<:IANumTypes}
+    @eval function linear_dominated_bounder(fT::TaylorModelN{N,$TT,S};
+            ϵ=1e-5, max_iter=5) where {N,T<:IANumTypes, S<:IANumTypes}
         d = one(T)
         dom = domain(fT)
         x0 = expansion_point(fT)
@@ -363,7 +363,7 @@ For this algorithm the linear part is bounded by solving a simple
 set of linear equations (compared to the iterative procedure by Makino & Berz).
 """
 function quadratic_fast_bounder(fT::TaylorModelN)
-    @assert get_numvars() == get_numvars(fT)
+    @assert get_numvars(space(fT)) == get_numvars(fT)
     P = polynomial(fT)
     dom = domain(fT)
     x0 = expansion_point(fT)
@@ -372,7 +372,7 @@ function quadratic_fast_bounder(fT::TaylorModelN)
     if isposdef(mid.(H))
         P1 = -P[1].coeffs
         xn = H \ P1
-        x = variables()
+        x = variables(space(fT); order=TS.order(fT))
         Qxn = 0.5 * (x - xn)' * H * (x - xn)
         bound_qfb = (P - Qxn)(dom - x0)
         hi = sup(P(dom - x0))

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -124,7 +124,7 @@ mutable struct TaylorModelN{N,T,S} <: AbstractSeries{T}
             x0::SVector{N,Interval{S}}, dom::SVector{N,Interval{S}}) where
             {N,T<:NumberNotSeries,S<:Real}
 
-        @assert N == get_numvars()
+        @assert N == get_numvars(space(pol))
         @assert in_interval(zero(S), rem) && all(issubset_interval.(x0, dom))
 
         return new{N,T,S}(pol, rem, x0, dom)
@@ -135,14 +135,14 @@ end
 function TaylorModelN{N,T,S}(pol::TaylorN{T}, rem::Interval{S},
         x0::AbstractVector{Interval{S}}, dom::AbstractVector{Interval{S}}) where
         {N,T<:NumberNotSeries,S<:Real}
-    @assert N == get_numvars()
+    @assert N == get_numvars(pol)
     return TaylorModelN{N,T,S}(pol, rem, SVector{N}(x0), SVector{N}(dom))
 end
 
 function TaylorModelN(pol::TaylorN{T}, rem::Interval{S},
         x0::AbstractVector{Interval{S}}, dom::AbstractVector{Interval{S}}) where
         {T<:NumberNotSeries,S<:Real}
-    N = get_numvars()
+    N = get_numvars(pol)
     return TaylorModelN{N,T,S}(pol, rem, SVector{N}(x0), SVector{N}(dom))
 end
 
@@ -154,14 +154,23 @@ TaylorModelN(pol::TaylorN{T}, rem::Interval{S}, x0::SVector{N,Interval{S}},
 TaylorModelN(nv::Integer, ord::Integer, x0::AbstractVector{Interval{T}},
         dom::AbstractVector{Interval{T}}) where {T} =
     TaylorModelN(x0[nv] + TaylorN(Interval{T}, nv, order=ord), zero(dom[1]), x0, dom)
+TaylorModelN(space::JetSpace, nv::Integer, ord::Integer, x0::AbstractVector{Interval{T}},
+        dom::AbstractVector{Interval{T}}) where {T} =
+    TaylorModelN(x0[nv] + TaylorN(space, Interval{T}, nv, order=ord), zero(dom[1]), x0, dom)
 
 # Short-cut for a constant
 TaylorModelN(a::Interval{T}, ord::Integer, x0::AbstractVector{Interval{T}},
         dom::AbstractVector{Interval{T}}) where {T} =
     TaylorModelN(TaylorN(a, ord), zero(dom[1]), x0, dom)
+TaylorModelN(space::JetSpace, a::Interval{T}, ord::Integer, x0::AbstractVector{Interval{T}},
+        dom::AbstractVector{Interval{T}}) where {T} =
+    TaylorModelN(TaylorN(space, a, ord), zero(dom[1]), x0, dom)
 TaylorModelN(a::T, ord::Integer, x0::AbstractVector{<:Interval{T}},
         dom::AbstractVector{Interval{T}}) where {T} =
     TaylorModelN(TaylorN(a, ord), zero(dom[1]), x0, dom)
+TaylorModelN(space::JetSpace, a::T, ord::Integer, x0::AbstractVector{<:Interval{T}},
+        dom::AbstractVector{Interval{T}}) where {T} =
+    TaylorModelN(TaylorN(space, a, ord), zero(dom[1]), x0, dom)
 
 # Constructor for just changing the remainder
 TaylorModelN!(u::TaylorModelN{N,T,S}, Δ::Interval{S}) where {N,T,S} =

--- a/src/constructors.jl
+++ b/src/constructors.jl
@@ -175,5 +175,6 @@ TaylorModelN!(u::TaylorModelN{N,T,S}, Δ::Interval{S}) where {N,T,S} =
 @inline domain(tm::TaylorModelN) = tm.dom
 @inline expansion_point(tm::TaylorModelN) = tm.x0
 @inline get_numvars(::TaylorModelN{N,T,S}) where {N,T,S} = N
+@inline TS.space(a::TaylorModelN{N,T,S}) where {N,T,S} = space(polynomial(a))
 # Centered domain
 @inline centered_dom(tm::TaylorModelN) = domain(tm) .- expansion_point(tm)

--- a/src/evaluate.jl
+++ b/src/evaluate.jl
@@ -69,7 +69,7 @@ end
 function _evaluate(tmg::TaylorModel1{T,S}, tmf::TaylorModelN{N,T,S}) where{N,T,S}
     _order = TS.order(tmf)
     @assert _order == TS.order(tmg)
-    tmres = TaylorModelN(zero(constant_term(tmg.pol)), _order,
+    tmres = TaylorModelN(space(tmf), zero(constant_term(tmg.pol)), _order,
         expansion_point(tmf), domain(tmf))
     @inbounds for k = _order:-1:0
         tmres = tmres * tmf

--- a/src/integration.jl
+++ b/src/integration.jl
@@ -102,13 +102,13 @@ end
 function integrate(fT::TaylorModelN, which=1)
     p̂ = integrate(fT.pol, which)
     order = TS.order(fT)
-    r = TaylorN(p̂.coeffs[1:order+1])
-    s = TaylorN(p̂.coeffs[order+2:end])
+    r = TaylorN(space(fT), p̂.coeffs[1:order+1])
+    s = TaylorN(space(fT), p̂.coeffs[order+2:end])
     Δ = bound_integration(fT, s, which)
     return TaylorModelN(r, Δ, expansion_point(fT), domain(fT))
 end
 function integrate(fT::TaylorModelN, s::Symbol)
-    which = TaylorSeries.lookupvar(s)
+    which = TS.lookupvar(space(fT), s)
     return integrate(fT, which)
 end
 

--- a/src/rpa_functions.jl
+++ b/src/rpa_functions.jl
@@ -279,7 +279,8 @@ function fp_rpa(tm::TaylorModel1{TaylorN{S},T}) where
     D = symmetric_box(N)
 
     b = zero(fT)
-    t = Taylor1(TaylorN([zeros(HomogeneousPolynomial{T},order)], order), TS.order(fT))
+    t = Taylor1(TaylorN(space(tm.pol),
+        [zeros(HomogeneousPolynomial{T},order)], order), TS.order(fT))
     for ind in eachindex(fT)
         for homPol in eachindex(fT[ind])
             for jind in eachindex(fT[ind][homPol])
@@ -303,7 +304,7 @@ function fp_rpa(tm::TaylorModelN{N,Interval{T},T}) where {N,T}
     order = TS.order(tm)
 
     b = zero(fT)
-    t = TaylorN([HomogeneousPolynomial(zeros(T,N))], order)
+    t = TaylorN(space(tm), [HomogeneousPolynomial(space(tm), zeros(T,N))], order)
     for ind = 0:order
         @inbounds for homPol in eachindex(fT[ind])
             t[ind][homPol] = mid(fT[ind][homPol])

--- a/src/valid_integ/ValidatedInteg.jl
+++ b/src/valid_integ/ValidatedInteg.jl
@@ -10,6 +10,7 @@ using Parameters
 import Parameters: @unpack
 using StaticArrays
 
+import TaylorSeries: space
 export TMSol, TMSol3, flowpipe, get_xTM
 export shrink_wrapping!, absorb_remainder
 export validated_integ, validated_integ2, validated_integ3

--- a/src/valid_integ/integ_utils.jl
+++ b/src/valid_integ/integ_utils.jl
@@ -17,7 +17,8 @@ function shrink_wrapping!(xTMN::Vector{TaylorModelN{N,T,S}}) where {N,T,S}
 
     # Vector of independent TaylorN variables
     order = TS.order(xTMN[1])
-    X = [TaylorN(T, i, order=order) for i in 1:N]
+    # X = [TaylorN(T, i, order=order) for i in 1:N]
+    X = variables(space(xTMN[1]), order=order)
 
     # Remainder of original TaylorModelN and componentwise mag
     rem = remainder.(xTMN)
@@ -113,7 +114,7 @@ end
 # Postverify and define Taylor models to be returned
 for TT in (:T, :(Interval{T}))
     @eval function scalepostverify_sw!(xTMN::Vector{TaylorModelN{N,$TT,S}},
-            X::Vector{TaylorN{$TT}}) where {N,T<:IANumTypes, S<:IANumTypes}
+            X::Vector{TaylorN{T}}) where {N,T, S<:IANumTypes}
         postverify = true
         x0 = expansion_point(xTMN[1])
         B = domain(xTMN[1])
@@ -158,7 +159,7 @@ function absorb_remainder(a::TaylorModelN{N,T,T}) where {N,T}
     rem = zero(Δ)
 
     # Linear shift
-    lin_shift = mid(Δ) + sum((aux*TaylorN(i, order=orderQ) for i in 1:N))
+    lin_shift = mid(Δ) + aux*sum((TaylorN(space(a), i, order=orderQ) for i in 1:N))
     bpol = polynomial(a) + lin_shift
 
     # Compute the new remainder

--- a/test/TMN.jl
+++ b/test/TMN.jl
@@ -22,7 +22,8 @@ end
 @testset "Tests for TaylorModelN " begin
     local _order = 2
     local _order_max = 2*(_order+1)
-    variables!(Interval{Float64}, "x y", order=_order_max; nowarn=true)
+    local jspace = JetSpace(_order_max, ["x", "y"])
+    # variables!(Interval{Float64}, "x y", order=_order_max; nowarn=true)
 
     b0 = [interval(0.0), interval(0.0)]
     ib0 = [interval(-0.5, 0.5), interval(-0.5, 0.5)]
@@ -30,25 +31,25 @@ end
     ib1 = [interval(-0.5, 0.5), interval(0.5, 1.5)]
 
     zi = interval(0)
-    xT = TaylorN(Interval{Float64}, 1, order=_order)
-    yT = TaylorN(Interval{Float64}, 2, order=_order)
+    xT = TaylorN(jspace, Interval{Float64}, 1, order=_order)
+    yT = TaylorN(jspace, Interval{Float64}, 2, order=_order)
 
     @testset "TaylorModelN constructors" begin
-        xm = TaylorModelN{_order,Interval{Float64}, Float64}(xT, zi, b0, ib0)
-        ym = TaylorModelN{_order,Interval{Float64}, Float64}(yT, zi, b0, ib0)
+        xm = TaylorModelN{_order, Interval{Float64}, Float64}(xT, zi, b0, ib0)
+        ym = TaylorModelN{_order, Interval{Float64}, Float64}(yT, zi, b0, ib0)
         @test xm == TaylorModelN(xT, zi, b0, ib0)
         @test ym == TaylorModelN(yT, zi, b0, ib0)
-        @test xm == TaylorModelN(1, _order, b0, ib0)
-        @test ym == TaylorModelN(2, _order, b0, ib0)
-        @test TaylorModelN( b1[1], 2, b0, ib0) ==
-                TaylorModelN(TaylorN(b1[1], _order), zi, b0, ib0)
+        @test xm == TaylorModelN(jspace, 1, _order, b0, ib0)
+        @test ym == TaylorModelN(jspace, 2, _order, b0, ib0)
+        @test TaylorModelN(jspace, b1[1], 2, b0, ib0) ==
+                TaylorModelN(TaylorN(jspace, b1[1], _order), zi, b0, ib0)
 
         xm1 = TaylorModelN{_order,Interval{Float64}, Float64}(xT, zi, b0, ib0)
         TaylorModelN!(xm1, interval(-1,1))
         @test xm1 == TaylorModelN(xT, interval(-1,1), b0, ib0)
         TaylorModelN!(xm1, zi)
-        @test TaylorModelN(1, _order, b0, ib0) == xm1
-        @test TaylorModelN(2, _order, b0, ib0) == ym
+        @test TaylorModelN(jspace, 1, _order, b0, ib0) == xm1
+        @test TaylorModelN(jspace, 2, _order, b0, ib0) == ym
 
         @test isa(xm, AbstractSeries)
         @test TaylorModelN{2,Interval{Float64},Float64} <: AbstractSeries{Interval{Float64}}
@@ -60,7 +61,7 @@ end
         @test_throws BoundsError TaylorModelN(5, _order, b0, ib0) # wrong variable number
 
         # Tests for order and remainder
-        @test TS.order() == 6
+        @test TS.order(jspace) == 6
         @test TS.order(xm) == 2
         @test isequal_interval(domain(xm), ib0)
         @test isequal_interval(remainder(ym), zi)
@@ -103,8 +104,8 @@ end
         b = b1[2] * a
         @test b == TaylorModelN( b1[2]*a_pol, Δ*b1[2], b1, ib1 )
         @test b / b1[2] == a
-        @test_throws AssertionError TaylorModelN(TaylorN(1, order=_order_max), zi, b1, ib1) *
-            TaylorModelN(TaylorN(2, order=_order_max), zi, b1, ib1)
+        @test_throws AssertionError TaylorModelN(TaylorN(jspace, 1, order=_order_max), zi, b1, ib1) *
+            TaylorModelN(TaylorN(jspace, 2, order=_order_max), zi, b1, ib1)
 
         remt = remainder(1/(1-TaylorModel1(_order, b1[1], ib1[1])))
         @test isequal_interval(remainder(1 / (1-xm)), remt)
@@ -116,8 +117,8 @@ end
     end
 
     @testset "RPAs, functions and remainders" begin
-        xm = TaylorModelN(1, _order, b1, ib1)
-        ym = TaylorModelN(2, _order, b1, ib1)
+        xm = TaylorModelN(jspace, 1, _order, b1, ib1)
+        ym = TaylorModelN(jspace, 2, _order, b1, ib1)
 
         @test rpa(x->5+zero(x), xm) == 5+zero(xm)
         @test rpa(x->5+one(x), ym) == 5+one(ym)
@@ -263,8 +264,8 @@ end
     @testset "Tests for integrate" begin
         ib0 = [interval(0., 1.), interval(0., 1.)]
         b0 = [interval(0.5, 0.5), interval(0.5, 0.5)]
-        xm = TaylorModelN(1, _order, b0, ib0)
-        ym = TaylorModelN(2, _order, b0, ib0)
+        xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+        ym = TaylorModelN(jspace, 2, _order, b0, ib0)
         xm.rem = interval(-0.25,0.25)
 
         f = (x, y) -> x
@@ -377,8 +378,8 @@ end
     end
 
     @testset "Display" begin
-        xm = TaylorModelN(1, _order, b1, ib1)
-        ym = TaylorModelN(2, _order, b1, ib1)
+        xm = TaylorModelN(jspace, 1, _order, b1, ib1)
+        ym = TaylorModelN(jspace, 2, _order, b1, ib1)
         use_show_default(true)
         @test string(xm+ym) == "TaylorModelN{2, Interval{Float64}, Float64}" *
             "(TaylorN{Interval{Float64}}(HomogeneousPolynomial{Interval{Float64}}" *
@@ -415,8 +416,8 @@ end
             ib0 = [interval(2.875, 3.0625), interval(0.5, 0.625)] # A box near global minimum
             c = mid.(ib0)
             b0 = [interval(c[1]), interval(c[2])]
-            xm = TaylorModelN(1, _order, b0, ib0)
-            ym = TaylorModelN(2, _order, b0, ib0)
+            xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+            ym = TaylorModelN(jspace, 2, _order, b0, ib0)
             fT = beale(xm, ym)
             bound_naive_tm = fT(centered_dom(fT))
             bound_ldb = linear_dominated_bounder(fT)
@@ -424,8 +425,8 @@ end
             @test in_interval(beale_min, bound_ldb)
 
             # Same as previous, but with Float64 coefficients
-            xT = TaylorN(Float64, 1, order=_order)
-            yT = TaylorN(Float64, 2, order=_order)
+            xT = TaylorN(jspace, Float64, 1, order=_order)
+            yT = TaylorN(jspace, Float64, 2, order=_order)
             xT = xT + c[1]
             yT = yT + c[2]
             xm = TaylorModelN(xT, interval(0), b0, ib0)
@@ -437,16 +438,16 @@ end
             ib0 = [interval(2.875, 3.0625), interval(0.375, 0.5)]
             c = mid.(ib0)
             b0 = [interval(c[1]), interval(c[2])]
-            xm = TaylorModelN(1, _order, b0, ib0)
-            ym = TaylorModelN(2, _order, b0, ib0)
+            xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+            ym = TaylorModelN(jspace, 2, _order, b0, ib0)
             fT = beale(xm, ym)
             bound_naive_tm = fT(centered_dom(fT))
             bound_ldb = linear_dominated_bounder(fT)
             @test issubset_interval(bound_ldb, bound_naive_tm)
             @test in_interval(beale_min, bound_ldb)
 
-            xT = TaylorN(Float64, 1, order=_order)
-            yT = TaylorN(Float64, 2, order=_order)
+            xT = TaylorN(jspace, Float64, 1, order=_order)
+            yT = TaylorN(jspace, Float64, 2, order=_order)
             xT = xT + c[1]
             yT = yT + c[2]
             xm = TaylorModelN(xT, interval(0), b0, ib0)
@@ -460,15 +461,15 @@ end
             ib0 = [interval(1.01176, 1.1353), interval(0.888235, 1.01177)]
             c = mid.(ib0)
             b0 = [interval(c[1]), interval(c[2])]
-            xm = TaylorModelN(1, _order, b0, ib0)
-            ym = TaylorModelN(2, _order, b0, ib0)
+            xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+            ym = TaylorModelN(jspace, 2, _order, b0, ib0)
             fT = rosenbrock(xm, ym)
             bound_naive_tm = fT(centered_dom(fT))
             bound_ldb = linear_dominated_bounder(fT)
             @test issubset_interval(bound_ldb, bound_naive_tm)
 
-            xT = TaylorN(Float64, 1, order=_order)
-            yT = TaylorN(Float64, 2, order=_order)
+            xT = TaylorN(jspace, Float64, 1, order=_order)
+            yT = TaylorN(jspace, Float64, 2, order=_order)
             xT = xT + c[1]
             yT = yT + c[2]
             xm = TaylorModelN(xT, zi, b0, ib0)
@@ -481,15 +482,15 @@ end
             ib0 = [interval(-0.647059, -0.588235), interval(-1.58824, -1.52941)]
             c = mid.(ib0)
             b0 = [interval(c[1]), interval(c[2])]
-            xm = TaylorModelN(1, _order, b0, ib0)
-            ym = TaylorModelN(2, _order, b0, ib0)
+            xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+            ym = TaylorModelN(jspace, 2, _order, b0, ib0)
             fT = mccormick(xm, ym)
             bound_naive_tm = fT(centered_dom(fT))
             bound_ldb = linear_dominated_bounder(fT)
             @test issubset_interval(bound_ldb, bound_naive_tm)
 
-            xT = TaylorN(Float64, 1, order=_order)
-            yT = TaylorN(Float64, 2, order=_order)
+            xT = TaylorN(jspace, Float64, 1, order=_order)
+            yT = TaylorN(jspace, Float64, 2, order=_order)
             xT = xT + c[1]
             yT = yT + c[2]
             xm = TaylorModelN(xT, zi, b0, ib0)
@@ -505,8 +506,8 @@ end
             ib0 = [interval(3 - δ, 3 + δ), interval(0.5 - δ, 0.5 + δ)]
             c = mid.(ib0)
             b0 = [interval(c[1]), interval(c[2])]
-            xm = TaylorModelN(1, _order, b0, ib0)
-            ym = TaylorModelN(2, _order, b0, ib0)
+            xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+            ym = TaylorModelN(jspace, 2, _order, b0, ib0)
             fT = beale(xm, ym)
             bound_naive_tm = fT(centered_dom(fT))
             bound_qfb = quadratic_fast_bounder(fT)
@@ -516,8 +517,8 @@ end
             ib0 = [interval(1. - δ, 1. + δ), interval(1. - δ, 1 + δ)]
             c = mid.(ib0)
             b0 = [interval(c[1]), interval(c[2])]
-            xm = TaylorModelN(1, _order, b0, ib0)
-            ym = TaylorModelN(2, _order, b0, ib0)
+            xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+            ym = TaylorModelN(jspace, 2, _order, b0, ib0)
             fT = rosenbrock(xm, ym)
             bound_naive_tm = fT(centered_dom(fT))
             bound_qfb = quadratic_fast_bounder(fT)
@@ -528,8 +529,8 @@ end
                     interval(-1.54719 - δ, -1.54719 + δ)]
             c = mid.(ib0)
             b0 = [interval(c[1]), interval(c[2])]
-            xm = TaylorModelN(1, _order, b0, ib0)
-            ym = TaylorModelN(2, _order, b0, ib0)
+            xm = TaylorModelN(jspace, 1, _order, b0, ib0)
+            ym = TaylorModelN(jspace, 2, _order, b0, ib0)
             fT = mccormick(xm, ym)
             bound_naive_tm = fT(centered_dom(fT))
             bound_qfb = quadratic_fast_bounder(fT)


### PR DESCRIPTION
This PR imposes a more consistent use of `JetSpace`s in TaylorModels. Among other, it's aimed to improve the performance.